### PR TITLE
gles3.20160307.alpha - via opam-publish

### DIFF
--- a/packages/gles3/gles3.20160307.alpha/descr
+++ b/packages/gles3/gles3.20160307.alpha/descr
@@ -1,0 +1,25 @@
+OCaml GLES 3.0 bindings
+
+This project aims at providing a portable way to do OpenGL (precisely
+GLES) application using OCaml. It comes in three parts:
+     * Low level bindings which allow to call directly GLES functions.
+       This binding tries to be reasonably type-safe using polymorphic
+       variants to encode Glenum type. The low level bindings also provide
+       some sanity checks for the size of bigarrays which allow to capture
+       quite a lot of errors with clear messages.
+     * High level bindings: to provide some auxiliary functions like
+       matrix inversion and ease the development. For instance, to use
+       shaders, with the high level bindings, you use compile_shader with
+       the sources code, get a value of type unit program. Then, you can
+       set the variables of the shaders (uniform or attributes), either as
+       constant or function and get a function to finally run the shaders.
+     * A way to open a window, start the main loop and interact. Currently
+       only EGL under X11 is supported but it would be nice to have
+       support for other platforms (windows, OSX, android, ios, wayland,
+       ...) with exactly the same interface.
+
+Authors
+
+     * [3]Alexandre Miquel (initial low level bindings for GLES 2)
+     * [4]Christophe Raffalli (partial port to GLES 3.0, high-level
+       bindings and examples)

--- a/packages/gles3/gles3.20160307.alpha/opam
+++ b/packages/gles3/gles3.20160307.alpha/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "Christophe Raffalli <raffalli@univ-savoie.fr>"
+authors:
+  "Christophe Raffalli <raffalli@univ-savoie.fr>, Alexandre Miquel<amiquel@fing.edu.uy>"
+homepage: "http://lama.univ-savoie.fr/~raffalli/gles3"
+bug-reports: "raffalli@univ-savoie.fr"
+license: "LGPL"
+dev-repo: "darcs://lama.univ-savoie.fr/~raffalli/gles3/repos"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "gles3"]
+depends: [
+  "ocamlfind" {build}
+]

--- a/packages/gles3/gles3.20160307.alpha/url
+++ b/packages/gles3/gles3.20160307.alpha/url
@@ -1,0 +1,3 @@
+http:
+  "https://lama.univ-savoie.fr/~raffalli/gles3/gles3-20160307.alpha.tar.gz"
+checksum: "dc124607e7013e5561a3b600f7dd5e41"


### PR DESCRIPTION
OCaml GLES 3.0 bindings

This project aims at providing a portable way to do OpenGL (precisely
GLES) application using OCaml. It comes in three parts:
     * Low level bindings which allow to call directly GLES functions.
       This binding tries to be reasonably type-safe using polymorphic
       variants to encode Glenum type. The low level bindings also provide
       some sanity checks for the size of bigarrays which allow to capture
       quite a lot of errors with clear messages.
     * High level bindings: to provide some auxiliary functions like
       matrix inversion and ease the development. For instance, to use
       shaders, with the high level bindings, you use compile_shader with
       the sources code, get a value of type unit program. Then, you can
       set the variables of the shaders (uniform or attributes), either as
       constant or function and get a function to finally run the shaders.
     * A way to open a window, start the main loop and interact. Currently
       only EGL under X11 is supported but it would be nice to have
       support for other platforms (windows, OSX, android, ios, wayland,
       ...) with exactly the same interface.

Authors

     * [3]Alexandre Miquel (initial low level bindings for GLES 2)
     * [4]Christophe Raffalli (partial port to GLES 3.0, high-level
       bindings and examples)


---
* Homepage: http://lama.univ-savoie.fr/~raffalli/gles3
* Source repo: darcs://lama.univ-savoie.fr/~raffalli/gles3/repos
* Bug tracker: raffalli@univ-savoie.fr

---

Pull-request generated by opam-publish v0.3.1